### PR TITLE
kosir/patchConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ $ vault write hcp/config \
 # read configuration
 $ vault read hcp/config
 
+# patch configuration
+$ vault patch hcp/config organization="..."
+
 # rotate initial credentials
 $ vault write -f hcp/config/rotate
 

--- a/path_config_rotate.go
+++ b/path_config_rotate.go
@@ -42,7 +42,11 @@ func (b *hcpBackend) pathConfigRotateWrite(ctx context.Context, req *logical.Req
 		return nil, err
 	}
 
-	if err := replaceConfigServicePrincipalKey(ctx, req, newSPK); err != nil {
+	patch := &hcpConfig{
+		ClientID:     newSPK.Key.ClientID,
+		ClientSecret: newSPK.ClientSecret,
+	}
+	if err := patchConfig(ctx, req, patch); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
# Overview
Added `pathConfigPatch` to allow the user to patch a specific item of the config rather the writing the entire config again. Leverage `patchConfig` when rotating initial credentials.